### PR TITLE
Upgrade sentry to latest ~2.1

### DIFF
--- a/SentryComponent.php
+++ b/SentryComponent.php
@@ -195,10 +195,9 @@ class SentryComponent extends CApplicationComponent
 	{
 		$raven = $this->getRaven();
 		if ($raven) {
-			$handler = new Raven_ErrorHandler($raven);
-			$handler->registerExceptionHandler();
-			$handler->registerErrorHandler();
-			$handler->registerShutdownFunction();
+			ErrorHandler::registerOnceExceptionHandler();
+			ErrorHandler::registerOnceErrorHandler();
+			ErrorHandler::registerOnceFatalErrorHandler();
 
 			return true;
 		}

--- a/SentryLogRoute.php
+++ b/SentryLogRoute.php
@@ -25,6 +25,27 @@ class SentryLogRoute extends CLogRoute
 	 */
 	protected $raven;
 
+	public static function getSeverityFromLogLevel(string $level): Severity
+	{
+		$severityLevels = [
+			CLogger::LEVEL_PROFILE => Severity::debug(),
+			CLogger::LEVEL_TRACE   => Severity::debug(),
+			'debug'                => Severity::debug(),
+			CLogger::LEVEL_INFO    => Severity::info(),
+			CLogger::LEVEL_WARNING => Severity::warning(),
+			'warn'                 => Severity::warning(),
+			CLogger::LEVEL_ERROR   => Severity::error(),
+			'fatal'                => Severity::fatal(),
+		];
+
+		$level = strtolower($level);
+		if (array_key_exists($level, $severityLevels)) {
+			return $severityLevels[$level];
+		}
+
+		return Severity::error();
+	}
+
 	/**
 	 * @inheritdoc
 	 */

--- a/Tests/Unit/SentryComponentTest.php
+++ b/Tests/Unit/SentryComponentTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Skillshare\YiiSentry\Test;
+
+use CWebApplication;
+use IApplicationComponent;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Sentry\Client;
+use Sentry\ClientInterface;
+use Sentry\Event;
+use Sentry\SentrySdk;
+use Sentry\Severity;
+use Skillshare\YiiSentry\SentryComponent;
+use Yii;
+
+/**
+ * @coversDefaultClass \Skillshare\YiiSentry\SentryComponent
+ */
+class SentryComponentTest extends TestCase
+{
+	use MockeryPHPUnitIntegration;
+
+	private CWebApplication $app;
+
+	protected function setUp(): void
+	{
+		// Re-init Sentry
+		SentrySdk::init();
+
+		// Resets the app entirely between runs
+		Yii::setApplication(null);
+		$config    = [
+			'basePath'   => dirname(__DIR__) . '/runtime',
+			'components' => [
+				'db' => [
+					'connectionString' => 'sqlite::memory:',
+				],
+			],
+		];
+		$this->app = Yii::createWebApplication($config);
+	}
+
+	/**
+	 * @covers ::getRaven
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getComponent
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getUserContext
+	 * @uses \Skillshare\YiiSentry\SentryComponent::registerRaven
+	 */
+	public function testGetRaven(): void
+	{
+		$sut = new SentryComponent();
+		$out = $sut->getRaven();
+		$this->assertInstanceOf(ClientInterface::class, $out);
+	}
+
+	/**
+	 * @covers ::getRaven
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getComponent
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getUserContext
+	 * @uses \Skillshare\YiiSentry\SentryComponent::registerRaven
+	 */
+	public function testGetRavenWithPreExisting(): void
+	{
+		$sut = new SentryComponent();
+		/** @var ClientInterface&MockInterface $raven */
+		$raven = Mockery::mock(ClientInterface::class);
+
+		$ref = new ReflectionProperty($sut, 'raven');
+		$ref->setAccessible(true);
+		$ref->setValue($sut, $raven);
+
+		$out = $sut->getRaven();
+		$this->assertInstanceOf(ClientInterface::class, $out);
+		$this->assertSame($raven, $out, 'Should return pre-established property');
+	}
+
+	/**
+	 * @covers ::registerRaven
+	 * @covers ::getUserContext
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getComponent
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getRaven
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getUserContext
+	 */
+	public function testRegisterRaven()
+	{
+		$dsn       = 'http://tim:tam@bob.com/8675309';
+		$publicKey = 'tim';
+		$secretKey = 'tam';
+		$dsnHost   = 'bob.com';
+		$projectId = 8675309;
+
+		$environment = 'dev';
+		$release     = 'dev_release';
+		$callback    = fn($i) => 1;
+
+		$sut          = new SentryComponent();
+		$sut->options = [
+			'dsn'         => $dsn,
+			'environment' => $environment,
+			'release'     => $release,
+			'before_send' => $callback,
+		];
+
+		$out = $sut->getRaven();
+		$this->assertInstanceOf(ClientInterface::class, $out);
+		$options = $out->getOptions();
+		$this->assertSame($environment, $options->getEnvironment());
+		$this->assertSame($release, $options->getRelease());
+		$this->assertSame($callback, $options->getBeforeSendCallback());
+
+		$dsnObj = $options->getDsn(false);
+		$this->assertSame($dsnHost, $dsnObj->getHost());
+		$this->assertSame($publicKey, $dsnObj->getPublicKey());
+		$this->assertSame($secretKey, $dsnObj->getSecretKey());
+		$this->assertSame($projectId, $dsnObj->getProjectId());
+	}
+
+	/**
+	 * @covers ::registerRaven
+	 * @covers ::getUserContext
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getComponent
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getRaven
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getUserContext
+	 */
+	public function testRegisterRavenWithUserContext(): void
+	{
+		$userId   = 37;
+		$userName = 'Dante';
+		$userInfo = ['id' => $userId, 'name' => strtoupper($userName)];
+
+		$sut = new SentryComponent();
+
+		/** @var IApplicationComponent&\Mockery\MockInterface $user */
+		$user = \Mockery::mock(IApplicationComponent::class);
+		$user->shouldReceive('getIsInitialized')->andReturnTrue();
+		$user->shouldReceive('getId')->andReturn($userId);
+		$user->shouldReceive('getName')->andReturn($userName);
+		$this->app->setComponent('user', $user);
+
+		$sut->getRaven()->captureMessage(
+			__METHOD__,
+			Severity::info(),
+			SentrySdk::getCurrentHub()->pushScope()
+		);
+		$scope            = SentrySdk::getCurrentHub()->pushScope();
+		$eventUserContext = $scope->applyToEvent(new Event(), [])->getUserContext()->toArray();
+		$this->assertEquals($userInfo, $eventUserContext, 'Scope should have received the user information');
+	}
+
+	/**
+	 * @covers ::registerRaven
+	 * @covers ::getUserContext
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getComponent
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getRaven
+	 * @uses \Skillshare\YiiSentry\SentryComponent::getUserContext
+	 */
+	public function testRegisterRavenWithGuestUserContext(): void
+	{
+		$userId   = 37;
+		$userName = 'Dante';
+		$userInfo = [];
+
+		$sut = new SentryComponent();
+
+		/** @var IApplicationComponent&\Mockery\MockInterface $user */
+		$user = \Mockery::mock(IApplicationComponent::class);
+		$user->shouldReceive('getIsInitialized')->andReturnTrue();
+		$user->isGuest = true;
+		$user->shouldReceive('getId')->andReturn($userId)->never();
+		$user->shouldReceive('getName')->andReturn($userName)->never();
+		$this->app->setComponent('user', $user);
+
+		$sut->getRaven()->captureMessage(
+			__METHOD__,
+			Severity::info(),
+			SentrySdk::getCurrentHub()->pushScope()
+		);
+		$scope            = SentrySdk::getCurrentHub()->pushScope();
+		$eventUserContext = $scope->applyToEvent(new Event(), [])->getUserContext()->toArray();
+		$this->assertEquals($userInfo, $eventUserContext, 'Scope should have received the user information');
+	}
+
+	/**
+	 * @coversNothing
+	 */
+	public function testEverything()
+	{
+		$sut = new SentryComponent();
+		$sut->init();
+
+		$callback = fn() => 1;
+
+		$sut->options = [
+			'dsn'         => 'http://tim:tam@bob.com/8675309',
+			'environment' => 'dev',
+			'release'     => 'dev_release',
+			'before_send' => $callback,
+		];
+
+		$raven = $sut->getRaven();
+
+		$this->assertInstanceOf(Client::class, $raven);
+		$options = $raven->getOptions();
+		$this->assertEquals('dev', $options->getEnvironment());
+		$this->assertEquals('dev_release', $options->getRelease());
+		$this->assertSame($callback, $options->getBeforeSendCallback());
+		$dsn = $options->getDsn(false);
+		$this->assertEquals(8675309, $dsn->getProjectId());
+		$this->assertEquals('tim', $dsn->getPublicKey());
+		$this->assertEquals('tam', $dsn->getSecretKey());
+		$this->assertEquals('bob.com', $dsn->getHost());
+	}
+}

--- a/Tests/Unit/SentryLogRouteTest.php
+++ b/Tests/Unit/SentryLogRouteTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Skillshare\YiiSentry\Test;
+
+use CLogger;
+use IApplicationComponent;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Sentry\ClientBuilder;
+use Sentry\ClientInterface;
+use Sentry\Event;
+use Sentry\Severity;
+use Sentry\Transport\TransportFactoryInterface;
+use Sentry\Transport\TransportInterface;
+use Skillshare\YiiSentry\SentryLogRoute;
+use Yii;
+
+/**
+ * @coversDefaultClass \Skillshare\YiiSentry\SentryLogRoute
+ * @uses \Skillshare\YiiSentry\SentryComponent
+ */
+class SentryLogRouteTest extends TestCase
+{
+	use MockeryPHPUnitIntegration;
+
+	public function severityLogLevelProvider()
+	{
+		$r = [];
+
+		$r['CLogger::PROFILE'] = [Severity::debug(), CLogger::LEVEL_PROFILE];
+		$r['CLogger::TRACE']   = [Severity::debug(), CLogger::LEVEL_TRACE];
+		$r['CLogger::INFO']    = [Severity::info(), CLogger::LEVEL_INFO];
+		$r['CLogger::WARNING'] = [Severity::warning(), CLogger::LEVEL_WARNING];
+		$r['CLogger::ERROR']   = [Severity::error(), CLogger::LEVEL_ERROR];
+		$r['Raw string debug'] = [Severity::debug(), 'debug',];
+		$r['Raw string warn']  = [Severity::warning(), 'warn'];
+		$r['Raw string fatal'] = [Severity::fatal(), 'fatal'];
+		$r['Raw string DEBUG'] = [Severity::debug(), 'DEBUG',];
+		$r['Raw string WARN']  = [Severity::warning(), 'WARN'];
+		$r['Raw string FATAL'] = [Severity::fatal(), 'FATAL'];
+		$r['Unknown is error'] = [Severity::error(), __CLASS__];
+		return $r;
+	}
+
+	/**
+	 * @covers ::getSeverityFromLogLevel
+	 * @dataProvider severityLogLevelProvider
+	 */
+	public function testSeverityFromLogLevel($expect, $level): void
+	{
+		$this->assertEquals($expect, SentryLogRoute::getSeverityFromLogLevel($level));
+	}
+
+	/**
+	 * @covers ::processLogs
+	 * @uses \Skillshare\YiiSentry\SentryLogRoute::getRaven
+	 * @uses \Skillshare\YiiSentry\SentryLogRoute::getSeverityFromLogLevel
+	 */
+	public function testProcessLogsWithNoRaven(): void
+	{
+		$logger = new CLogger();
+		$logger->log('Nothing');
+
+		$sut = $this->createSentryLogRouteWithRaven(null);
+		$this->assertNull($sut->collectLogs($logger, true));
+	}
+
+	/**
+	 * @covers ::processLogs
+	 * @uses \Skillshare\YiiSentry\SentryLogRoute::getRaven
+	 * @uses \Skillshare\YiiSentry\SentryLogRoute::getSeverityFromLogLevel
+	 */
+	public function testProcessLogs(): void
+	{
+		$message1  = 'Test Log Message';
+		$level1    = 'error';
+		$severity1 = Severity::error();
+		$category1 = __METHOD__;
+
+		$message2  = 'Another Test Log Message';
+		$level2    = 'warn';
+		$severity2 = Severity::warning();
+		$category2 = __CLASS__;
+
+		$raven = $this->getTestClientForLogs([
+			[$message1, $severity1, $category1],
+			[$message2, $severity2, $category2],
+		]);
+
+		$sut = $this->createSentryLogRouteWithRaven($raven);
+
+		$logger = new CLogger();
+		$logger->log($message1, $level1, $category1);
+		$logger->log($message2, $level2, $category2);
+
+		$sut->collectLogs($logger, true);
+	}
+
+	/**
+	 * @covers ::getRaven
+	 * @uses  \Skillshare\YiiSentry\SentryLogRoute::getSeverityFromLogLevel
+	 * @uses  \Skillshare\YiiSentry\SentryLogRoute::processLogs
+	 */
+	public function testGetRavenPreExisting()
+	{
+		$raven = $this->getTestClientForLogs([['Test', Severity::info(), 'application']]);
+		$sut   = $this->createSentryLogRouteWithRaven($raven);
+
+		$logger = new CLogger();
+		$logger->log('Test');
+		$sut->collectLogs($logger, true);
+	}
+
+	/**
+	 * @covers ::getRaven
+	 * @uses  \Skillshare\YiiSentry\SentryLogRoute::getSeverityFromLogLevel
+	 * @uses  \Skillshare\YiiSentry\SentryLogRoute::processLogs
+	 */
+	public function testGetRavenFromNonExistentComponent()
+	{
+		$sut = new SentryLogRoute();
+
+		$logger = new CLogger();
+		$logger->log('Test');
+		$sut->collectLogs($logger, true);
+		$this->assertTrue(true, 'Things should succeed without errors');
+	}
+
+	/**
+	 * @covers ::getRaven
+	 * @uses  \Skillshare\YiiSentry\SentryLogRoute::getSeverityFromLogLevel
+	 * @uses  \Skillshare\YiiSentry\SentryLogRoute::processLogs
+	 */
+	public function testGetRavenFromPreExistentComponent()
+	{
+		$raven = $this->getTestClientForLogs([['Test', Severity::info(), 'application']]);
+
+		/** @var IApplicationComponent&\Mockery\MockInterface $sentry */
+		$sentry = Mockery::mock(IApplicationComponent::class);
+		$sentry->shouldReceive('getIsInitialized')->andReturnTrue();
+		$sentry->shouldReceive('getRaven')->andReturn($raven);
+
+		$sut = new SentryLogRoute();
+		Yii::app()->setComponent($sut->sentryComponent, $sentry);
+
+		$logger = new CLogger();
+		$logger->log('Test');
+		$sut->collectLogs($logger, true);
+	}
+
+	protected function createSentryLogRouteWithRaven($raven): SentryLogRoute
+	{
+		$sut = new SentryLogRoute();
+
+		$ref = new ReflectionProperty($sut, 'raven');
+		$ref->setAccessible(true);
+		$ref->setValue($sut, $raven);
+		return $sut;
+	}
+
+	protected function getTestClientForLogs(array $logs): ClientInterface
+	{
+		/** @var TransportInterface&\Mockery\MockInterface $transport */
+		$transport = Mockery::mock(TransportInterface::class);
+		foreach ($logs as $log) {
+			[$message, $severity, $category] = $log;
+			$transport->shouldReceive('send')->withArgs(function (Event $event) use ($message, $severity, $category) {
+				self::assertEquals($message, $event->getMessage());
+				self::assertTrue($event->getLevel()->isEqualTo($severity), 'Log Level was not set correctly');
+				self::assertArrayHasKey('category', $event->getExtraContext(), 'Category should be set on event');
+				self::assertEquals($category, $event->getExtraContext()['category'], 'Category should be set correctly on event');
+				return true;
+			})->once();
+		}
+
+		/** @var TransportFactoryInterface&\Mockery\MockInterface $transportFactory */
+		$transportFactory = Mockery::mock(TransportFactoryInterface::class);
+		$transportFactory->shouldReceive('create')->andReturn($transport);
+		return ((new ClientBuilder())->setTransportFactory($transportFactory))->getClient();
+	}
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -18,4 +18,5 @@ $config = [
     ],
 ];
 
+Yii::$enableIncludePath = false;
 Yii::createWebApplication($config);

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "minimum-stability": "stable",
     "license": "MIT",
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.4.0",
         "yiisoft/yii": "^1.1",
-        "sentry/sentry": "^1.8"
+        "sentry/sdk": "^2.1"
     },
     "require-dev":{
         "phpunit/phpunit": "^8",

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,24 @@
 {
     "name": "skillshare/yii-sentry",
     "description": "Sentry component and LogRoute for Yii1",
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "license": "MIT",
     "require": {
         "php": ">=5.5.0",
+        "yiisoft/yii": "^1.1",
         "sentry/sentry": "^1.8"
     },
     "require-dev":{
-        "phpunit/phpunit": "~4.5"
+        "phpunit/phpunit": "^8",
+        "mockery/mockery": "^1.4"
     },
     "autoload": {
         "psr-4": {"Skillshare\\YiiSentry\\": ""}
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Skillshare\\YiiSentry\\Test\\": "Tests/Unit"
+        }
     },
     "authors" : []
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
         bootstrap="Tests/bootstrap.php"
-        colors="false"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        processIsolation="false"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        strict="false"
-        verbose="false">
+        executionOrder="depends,defects"
+        forceCoversAnnotation="true"
+        beStrictAboutCoversAnnotation="true"
+        beStrictAboutOutputDuringTests="true"
+        beStrictAboutTodoAnnotatedTests="true"
+        verbose="true"
+>
     <testsuites>
         <testsuite name="Unit tests">
-            <directory>Tests/Unit</directory>
+            <directory suffix="Test.php">Tests/Unit</directory>
         </testsuite>
     </testsuites>
+
     <filter>
-        <whitelist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <file>./SentryComponent.php</file>
+            <file>./SentryLogRoute.php</file>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
Upgrades the sentry integration from using [`sentry/sentry:^1.8`](https://packagist.org/packages/sentry/sentry#1.8.0) to using [`sentry/sdk:^2.1`](https://packagist.org/packages/sentry/sdk#2.1.0)

This is ahead of implementing Sentry integration in a different way in the monolith (and eventually retiring this package entirely). Since composer is unable to install different versions of the same package, I wanted to make sure this was up to date before trying to integrate over there.

There will be another PR in the monolith to update the usage of _this_ package in there, but I want to get this merged and a release tagged so that we can pin to a specific version.